### PR TITLE
Patch for dnsmasq 2.80

### DIFF
--- a/dnsmasq-2.80-filter-aaaa+https+unknown.patch
+++ b/dnsmasq-2.80-filter-aaaa+https+unknown.patch
@@ -1,0 +1,143 @@
+diff --git a/src/cache.c b/src/cache.c
+index 2f2c519..748a022 100644
+--- a/src/cache.c
++++ b/src/cache.c
+@@ -66,6 +66,7 @@ static const struct {
+   { 52,  "TLSA" },
+   { 53,  "SMIMEA" },
+   { 55,  "HIP" },
++  { 65,  "HTTPS"},
+   { 249, "TKEY" },
+   { 250, "TSIG" },
+   { 251, "IXFR" },
+@@ -1812,6 +1813,20 @@ char *record_source(unsigned int index)
+   return "<unknown>";
+ }
+ 
++// patch: function returns integer 1 if query type is unknown.
++// known types are defined in cache.c:typestr:36.
++int is_query_type_unknown(unsigned short type)
++{
++  unsigned int i;
++  for (i = 0; i < (sizeof(typestr)/sizeof(typestr[0])); i++)
++    if (typestr[i].type == type) 
++      {
++	return 0;
++      }
++  return 1;
++}
++// end of patch 
++
+ char *querystr(char *desc, unsigned short type)
+ {
+   unsigned int i;
+diff --git a/src/dns-protocol.h b/src/dns-protocol.h
+index 8edb9f3..2385b9e 100644
+--- a/src/dns-protocol.h
++++ b/src/dns-protocol.h
+@@ -71,6 +71,7 @@
+ #define T_NSEC          47
+ #define T_DNSKEY        48
+ #define T_NSEC3         50
++#define T_HTTPS         65
+ #define	T_TKEY		249		
+ #define	T_TSIG		250
+ #define T_AXFR          252
+diff --git a/src/dnsmasq.h b/src/dnsmasq.h
+index 4220798..7429734 100644
+--- a/src/dnsmasq.h
++++ b/src/dnsmasq.h
+@@ -269,7 +269,10 @@ struct event_desc {
+ #define OPT_TFTP_APREF_MAC 56
+ #define OPT_RAPID_COMMIT   57
+ #define OPT_UBUS           58
+-#define OPT_LAST           59
++#define OPT_FILTER_AAAA    59
++#define OPT_FILTER_HTTPS   60
++#define OPT_FILTER_UNKNOWN 61
++#define OPT_LAST           62
+ 
+ #define OPTION_BITS (sizeof(unsigned int)*8)
+ #define OPTION_SIZE ( (OPT_LAST/OPTION_BITS)+((OPT_LAST%OPTION_BITS)!=0) )
+@@ -1158,6 +1161,10 @@ void cache_init(void);
+ void next_uid(struct crec *crecp);
+ void log_query(unsigned int flags, char *name, union all_addr *addr, char *arg); 
+ char *record_source(unsigned int index);
++// patch: function returns integer 1 if query type is unknown
++// known types are defined in cache.c:typestr:36.
++int is_query_type_unknown(unsigned short type);
++// end of patch
+ char *querystr(char *desc, unsigned short type);
+ int cache_find_non_terminal(char *name, time_t now);
+ struct crec *cache_find_by_addr(struct crec *crecp,
+diff --git a/src/option.c b/src/option.c
+index dbe5f90..2e90b9a 100644
+--- a/src/option.c
++++ b/src/option.c
+@@ -167,6 +167,9 @@ struct myoption {
+ #define LOPT_UBUS          354
+ #define LOPT_NAME_MATCH    355
+ #define LOPT_CAA           356
++#define LOPT_FILTER_AAAA   357
++#define LOPT_FILTER_HTTPS  358
++#define LOPT_FILTER_UNKNOWN 359
+  
+ #ifdef HAVE_GETOPT_LONG
+ static const struct option opts[] =  
+@@ -339,6 +342,9 @@ static const struct myoption opts[] =
+     { "dhcp-rapid-commit", 0, 0, LOPT_RAPID_COMMIT },
+     { "dumpfile", 1, 0, LOPT_DUMPFILE },
+     { "dumpmask", 1, 0, LOPT_DUMPMASK },
++    { "filter-aaaa", 0, 0, LOPT_FILTER_AAAA },
++    { "filter-https", 0, 0, LOPT_FILTER_HTTPS },
++    { "filter-unknown", 0, 0, LOPT_FILTER_UNKNOWN },
+     { NULL, 0, 0, 0 }
+   };
+ 
+@@ -518,6 +524,9 @@ static struct {
+   { LOPT_RAPID_COMMIT, OPT_RAPID_COMMIT, NULL, gettext_noop("Enables DHCPv4 Rapid Commit option."), NULL },
+   { LOPT_DUMPFILE, ARG_ONE, "<path>", gettext_noop("Path to debug packet dump file"), NULL },
+   { LOPT_DUMPMASK, ARG_ONE, "<hex>", gettext_noop("Mask which packets to dump"), NULL },
++  { LOPT_FILTER_AAAA, OPT_FILTER_AAAA, NULL, gettext_noop("Filter all AAAA requests."), NULL },
++  { LOPT_FILTER_HTTPS, OPT_FILTER_HTTPS, NULL, gettext_noop("Filter all HTTPS/query type 65 requests."), NULL },
++  { LOPT_FILTER_UNKNOWN, OPT_FILTER_UNKNOWN, NULL, gettext_noop("Filter all unknown query types (known are defined in cache.c)."), NULL },
+   { 0, 0, NULL, NULL, NULL }
+ }; 
+ 
+diff --git a/src/rfc1035.c b/src/rfc1035.c
+index fefe63d..71bfa51 100644
+--- a/src/rfc1035.c
++++ b/src/rfc1035.c
+@@ -1955,6 +1955,32 @@ size_t answer_request(struct dns_header *header, char *limit, size_t qlen,
+ 	    }
+ 	}
+ 
++    //patch to filter aaaa forwards
++    if (qtype == T_AAAA && option_bool(OPT_FILTER_AAAA) ){
++        //return a null reply
++        ans = 1;
++        if (!dryrun) log_query(F_CONFIG | F_IPV6 | F_NEG, name, &addr, NULL);
++            break;
++    }
++    //end of patch
++    //patch to filter https/query type 65 forwards
++    if (qtype == T_HTTPS && option_bool(OPT_FILTER_HTTPS) ){
++        //return a null reply
++        ans = 1;
++        if (!dryrun) log_query(F_CONFIG | F_IPV4 | F_NEG, name, &addr, NULL);
++            break;
++    }
++    //end of patch
++    //patch to filter all unknown query types
++    //known types are defined in cache.c:typestr:36.
++    if (is_query_type_unknown(qtype) && option_bool(OPT_FILTER_UNKNOWN)) {
++        //return a null reply
++        ans = 1;
++        if (!dryrun) log_query(F_CONFIG | F_NEG, name, NULL, NULL);
++            break;
++    }
++    //end of patch
++
+       if (!ans)
+ 	return 0; /* failed to answer a question */
+     }


### PR DESCRIPTION
I had to adapt the patch for dnsmasq 2.80 since it's the version found in current Debian stable.
I took the liberty to remove some probably useless parts of the patch (whitespaces mostly) and I also removed the whole config.h part since I don't think it should be part of this kind of patch, but YMMV. In any case, please consider removing it also from the 2.82 patch.

I've tested this a few minutes ago and my iPhone finally falls back to plain old DNS! :tada: Thank you!